### PR TITLE
Add --per-proof-gas alias for --gas-per-proof

### DIFF
--- a/quick_cost_estimate.py
+++ b/quick_cost_estimate.py
@@ -8,12 +8,18 @@ def parse_args() -> argparse.Namespace:
     )
     p.add_argument("--num-proofs", type=int, required=True,
                    help="Number of proofs.")
-    p.add_argument("--gas-per-proof", type=int, required=True,
-                   help="On-chain gas cost per proof (verification, etc.).")
+      p.add_argument(
+        "--gas-per-proof", "--per-proof-gas",
+        dest="gas_per_proof",
+        type=int,
+        required=True,
+        help="On-chain gas cost per proof (verification, etc.).",
+    )
     p.add_argument("--gas-price-gwei", type=float, required=True,
                    help="Gas price in gwei (e.g. 30).")
     p.add_argument("--eth-price-usd", type=float, required=True,
                    help="ETH price in USD (e.g. 3200).")
+    
     return p.parse_args()
 
 


### PR DESCRIPTION
Common naming variation; keep backward compatible.