### PR TITLE
Turn “Installation” into a heading and use a list for Requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ Three built in proving system profiles are included:
 
 
 
-Installation
+## Installation
 
-Requirements:
+### Requirements
 
 - Python 3.10 or newer
 


### PR DESCRIPTION
Cleaner formatting and easier to scan.