### PR TITLE
Chore: add input validation for gas price and ETH price arguments

### DIFF
--- a/compare_schemes.py
+++ b/compare_schemes.py
@@ -15,6 +15,11 @@ def parse_args():
                    help="Gas price in gwei (e.g. 30).")
     p.add_argument("--eth-price-usd", type=float, required=True,
                    help="ETH price in USD (e.g. 3200).")
+    if args.gas_price_gwei <= 0:
+    raise ValueError("Gas price must be a positive number.")
+if args.eth_price_usd <= 0:
+    raise ValueError("ETH price must be a positive number.")
+
     return p.parse_args()
 
 def estimate_cost(num_proofs, gas_per_proof, gas_price_gwei, eth_price_usd):


### PR DESCRIPTION
## Summary

Currently, the script accepts raw input without validation. It would be beneficial to ensure that `gas-price-gwei` and `eth-price-usd` arguments are non-negative and within reasonable ranges to avoid erroneous calculations.

## Proposed Changes

- Add checks to ensure `gas-price-gwei` and `eth-price-usd` are positive values.
- Provide meaningful error messages if invalid values are passed (e.g. negative values or zero).

## Motivation

- Prevents users from inputting invalid arguments that would result in incorrect calculations or unexpected behavior.