### PR TITLE
Bugfix: fix typo in argument reference (`gas-per-proof-b` to `gas_per…

### DIFF
--- a/compare_schemes.py
+++ b/compare_schemes.py
@@ -33,12 +33,12 @@ def main():
     gas_b, eth_b, usd_b = estimate_cost(num, args.gas_per_proof_b, gas_price, eth_usd)
 
     print("Scheme A:")
-    print(f"  Gas per proof      : {args.gas_per_proof_a:,} gas")
+   print(f"  Gas per proof      : {args.gas_per_proof_a:,} gas")
     print(f"  Total gas (A)      : {gas_a:,} gas")
     print(f"  Total cost (A)     : {eth_a:.6f} ETH ≈ ${usd_a:,.2f}")
 
     print("\nScheme B:")
-    print(f"  Gas per proof      : {args.gas-per_proof_b:,} gas")
+    print(f"  Gas per proof      : {args.gas_per_proof_b:,} gas")
     print(f"  Total gas (B)      : {gas_b:,} gas")
     print(f"  Total cost (B)     : {eth_b:.6f} ETH ≈ ${usd_b:,.2f}")
 


### PR DESCRIPTION
…_proof_b`)

## Summary

There is a typo when printing the values for Scheme B. The argument reference `gas-per-proof-b` should be `gas_per_proof_b` to match the argument passed during argument parsing.

## Proposed Changes

- Update the reference to `args.gas_per_proof_b` in the print statement for Scheme B.

## Motivation

- Ensures that the output for Scheme B correctly reflects the provided input.