### PR TITLE
Feature: add --json flag to output results in JSON format

### DIFF
--- a/compare_schemes.py
+++ b/compare_schemes.py
@@ -15,6 +15,7 @@ def parse_args():
                    help="Gas price in gwei (e.g. 30).")
     p.add_argument("--eth-price-usd", type=float, required=True,
                    help="ETH price in USD (e.g. 3200).")
+    p.add_argument("--json", action="store_true", help="Output the result in JSON format")
     return p.parse_args()
 
 def estimate_cost(num_proofs, gas_per_proof, gas_price_gwei, eth_price_usd):
@@ -52,6 +53,27 @@ def main():
         print("  => Scheme B is cheaper.")
     else:
         print("  => Costs are equal.")
+import json
+if args.json:
+    print(json.dumps({
+        "Scheme A": {
+            "Gas per proof": args.gas_per_proof_a,
+            "Total gas": gas_a,
+            "Total cost (ETH)": eth_a,
+            "Total cost (USD)": usd_a
+        },
+        "Scheme B": {
+            "Gas per proof": args.gas_per_proof_b,
+            "Total gas": gas_b,
+            "Total cost (ETH)": eth_b,
+            "Total cost (USD)": usd_b
+        },
+        "Comparison": {
+            "Extra cost (ETH)": diff_eth,
+            "Extra cost (USD)": diff_usd
+        }
+    }, indent=4))
+    return
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary

For automated workflows, it would be beneficial to output the cost results in JSON format rather than plain text. This will make it easier for users to process the data programmatically.

## Proposed Changes

- Add a `--json` flag to the argument parser to output the results in JSON format.
- When `--json` is provided, print the output as a JSON object containing the results for both schemes.

## Motivation

- Facilitates integration with other systems, tools, or data pipelines that need structured data.